### PR TITLE
Fix the module key in the package json to point to index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/cosmology-tech/interchain#readme",
   "license": "SEE LICENSE IN LICENSE",
   "main": "main/index.js",
-  "module": "module/index.js",
+  "module": "main/index.js",
   "typings": "types/index.d.ts",
   "directories": {
     "lib": "src",


### PR DESCRIPTION
The actual build command's out dir is `main` not `module` and so vite resolution fails.

```
cross-env BABEL_ENV=production babel src --out-dir main --delete-dir-on-start --extensions ".tsx,.ts,.js"
```